### PR TITLE
example of using updated SupersetAPI policies in cocosign

### DIFF
--- a/.valint.rego
+++ b/.valint.rego
@@ -1,67 +1,41 @@
 package verify
 import data.superset.policy as policy
+
 default allow = false
 
-verify = v {
-  v := {
-    "allow": allow,
-    "violation": violation,
-    "errors": errors,
-    "summary": summary,
-  }
-}
-
 allow  {
-  policy.unmaintained.allow
   policy.cve.allow
-  policy.images.allow
-  policy.licences.allow
+  # policy.images.allow
+  # policy.licences.allow
+  # policy.unmaintained.allow
 }
 
-errors[msg] {
-  msg := policy.unmaintained.errors[_]
-}
+errors = [
+  policy.cve.errors,
+  # policy.images.errors,
+  # policy.licences.errors,
+  # policy.unmaintained.errors,
+]
 
-errors[msg] {
-  msg := policy.cve.errors[_]
-}
+violations = [
+  policy.cve.violations,
+  # policy.images.violations,
+  # policy.licences.violations,
+  # policy.unmaintained.violations,
+]
 
-errors[msg] {
-  msg := policy.images.errors[_]
-}
+summary = [
+  policy.cve.summary,
+  # policy.images.summary,
+  # policy.licences.summary,
+  # policy.unmaintained.summary,
+]
 
-errors[msg] {
-  msg := policy.licences.errors[_]
-}
 
-violation[msg] {
-  msg := policy.unmaintained.violation[_]
-}
-
-violation[msg] {
-  msg := policy.cve.violation[_]
-}
-
-violation[msg] {
-  msg := policy.images.violation[_]
-}
-
-violation[msg] {
-  msg := policy.licences.violation[_]
-}
-
-summary[msg] {
-  msg := policy.unmaintained.summary[_]
-}
-
-summary[msg] {
-  msg := policy.cve.summary[_]
-}
-
-summary[msg] {
-  msg := policy.images.summary[_]
-}
-
-summary[msg] {
-  msg := policy.licences.summary[_]
+verify = v {
+        v := {
+        "allow": allow,
+        "violations": violations,
+        "summary": summary,
+    }
 }

--- a/.valint.rego
+++ b/.valint.rego
@@ -1,41 +1,34 @@
 package verify
+
 import data.superset.policy as policy
 
 default allow = false
 
-allow  {
-  policy.cve.allow
-  # policy.images.allow
-  # policy.licences.allow
-  # policy.unmaintained.allow
-}
+allow = policy.cve.allow
+# allow = policy.images.allow
+# allow = policy.licences.allow
+# allow = policy.unmaintained.allow
 
-errors = [
-  policy.cve.errors,
-  # policy.images.errors,
-  # policy.licences.errors,
-  # policy.unmaintained.errors,
-]
+errors = policy.cve.errors
+# errors = policy.images.errors
+# errors = policy.licences.errors
+# errors = policy.unmaintained.errors,
 
-violations = [
-  policy.cve.violations,
-  # policy.images.violations,
-  # policy.licences.violations,
-  # policy.unmaintained.violations,
-]
+violation = policy.cve.violation
+# violation = policy.images.violation
+# violation = policy.licences.violation
+# violation = policy.unmaintained.violation
 
-summary = [
-  policy.cve.summary,
-  # policy.images.summary,
-  # policy.licences.summary,
-  # policy.unmaintained.summary,
-]
-
+summary = policy.cve.summary
+# summary = policy.images.summary
+# summary = policy.licences.summary
+# summary = policy.unmaintained.summary
 
 verify = v {
-        v := {
-        "allow": allow,
-        "violations": violations,
-        "summary": summary,
-    }
+	v := {
+		"allow": allow,
+		"violation": violation,
+		"summary": summary,
+		"errors": errors,
+	}
 }

--- a/.valint_pass.yaml
+++ b/.valint_pass.yaml
@@ -16,94 +16,19 @@ attest:
         type: verify-artifact
         name: superset-policy
         input:
+          signed: false
           format: attest-cyclonedx-json
           rego:
+            path: .valint.rego
             args:
               superset:
-                username: SUPERSET_USERNAME
-                password: SUPERSET_PASSWORD
-                env: dev
+                username: SMZ5qKFXMg7oe6ZmJjRv4BHzxXEKdqmX
+                password: gHXqCS-4TQYoIna6xwIkZ5NUhUdlCHWIymKHVMcshu1u8jqCf_5RIMSRRTl8gpto
                 licences:
-                  max: 5
+                  max: 500
                 cve:
-                  max: 70
+                  max: 3
                 unmaintained:
-                  max: 2
+                  max: 2000
                 images:
-                  max: 2
-                # licences:
-                #   max: 2
-                # cve:
-                #   max: 466
-                # unmaintained:
-                #   max: 34
-                # images:
-                #   max: 2
-            # script: |
-            #   package verify
-            #   import data.superset.policy as policy
-            #   default allow = false
-
-            #   verify = v {
-            #     v := {
-            #       "allow": allow,
-            #       "violation": violation,
-            #       "errors": errors,
-            #       "summary": summary,
-            #     }
-            #   }
-
-            #   allow  {
-            #     policy.unmaintained.allow
-            #     policy.cve.allow
-            #     policy.images.allow
-            #     policy.licences.allow
-            #   }
-
-            #   errors[msg] {
-            #     msg := policy.unmaintained.errors[_]
-            #   }
-
-            #   errors[msg] {
-            #     msg := policy.cve.errors[_]
-            #   }
-
-            #   errors[msg] {
-            #     msg := policy.images.errors[_]
-            #   }
-
-            #   errors[msg] {
-            #     msg := policy.licences.errors[_]
-            #   }
-
-            #   violation[msg] {
-            #     msg := policy.unmaintained.violation[_]
-            #   }
-
-            #   violation[msg] {
-            #     msg := policy.cve.violation[_]
-            #   }
-
-            #   violation[msg] {
-            #     msg := policy.images.violation[_]
-            #   }
-
-            #   violation[msg] {
-            #     msg := policy.licences.violation[_]
-            #   }
-
-            #   summary[msg] {
-            #     msg := policy.unmaintained.summary[_]
-            #   }
-
-            #   summary[msg] {
-            #     msg := policy.cve.summary[_]
-            #   }
-
-            #   summary[msg] {
-            #     msg := policy.images.summary[_]
-            #   }
-
-            #   summary[msg] {
-            #     msg := policy.licences.summary[_]
-            #   }
+                  max: 20

--- a/.valint_pass.yaml
+++ b/.valint_pass.yaml
@@ -22,8 +22,8 @@ attest:
             path: .valint.rego
             args:
               superset:
-                username: SMZ5qKFXMg7oe6ZmJjRv4BHzxXEKdqmX
-                password: gHXqCS-4TQYoIna6xwIkZ5NUhUdlCHWIymKHVMcshu1u8jqCf_5RIMSRRTl8gpto
+                username: CLIENT_ID
+                password: CLIENT_SECRET
                 licences:
                   max: 500
                 cve:


### PR DESCRIPTION
Rego policy updated to support the new version of superset policy api